### PR TITLE
Add simple Flask demand analysis app

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.12-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["python", "app.py"]

--- a/app.py
+++ b/app.py
@@ -1,0 +1,6 @@
+from app import create_app
+
+app = create_app()
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=5000)

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,10 @@
+from flask import Flask
+
+def create_app():
+    app = Flask(__name__)
+    app.config['SECRET_KEY'] = 'change-me'
+
+    from . import routes
+    app.register_blueprint(routes.bp)
+
+    return app

--- a/app/forecast.py
+++ b/app/forecast.py
@@ -1,0 +1,10 @@
+import pandas as pd
+
+def forecast_demand(df: pd.DataFrame, periods: int) -> pd.Series:
+    """Very basic moving average forecast."""
+    if 'demand' not in df.columns:
+        raise ValueError('CSV must contain a "demand" column')
+    rolling = df['demand'].rolling(window=3, min_periods=1).mean()
+    last_value = rolling.iloc[-1]
+    forecast = pd.Series([last_value] * periods, name='forecast')
+    return forecast

--- a/app/inventory.py
+++ b/app/inventory.py
@@ -1,0 +1,12 @@
+import pandas as pd
+from typing import Dict
+
+def compute_inventory_parameters(forecast: pd.Series, df: pd.DataFrame, lead_time: int = 1, service_level: float = 0.95) -> Dict[str, float]:
+    """Compute simple safety stock and reorder point."""
+    demand_std = df['demand'].std()
+    safety_stock = demand_std * (lead_time ** 0.5) * service_level
+    reorder_point = forecast.iloc[0] * lead_time + safety_stock
+    return {
+        'safety_stock': round(safety_stock, 2),
+        'reorder_point': round(reorder_point, 2),
+    }

--- a/app/routes.py
+++ b/app/routes.py
@@ -1,0 +1,20 @@
+from flask import Blueprint, request, render_template, redirect, url_for, flash
+import pandas as pd
+from .forecast import forecast_demand
+from .inventory import compute_inventory_parameters
+
+bp = Blueprint('main', __name__)
+
+@bp.route('/', methods=['GET', 'POST'])
+def upload_file():
+    if request.method == 'POST':
+        file = request.files.get('file')
+        periods = int(request.form.get('periods', 1))
+        if not file:
+            flash('No file selected')
+            return redirect(request.url)
+        df = pd.read_csv(file)
+        forecast = forecast_demand(df, periods)
+        params = compute_inventory_parameters(forecast, df)
+        return render_template('results.html', forecast=forecast.to_dict(), params=params)
+    return render_template('upload.html')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask>=3.0
+pandas>=2.2

--- a/templates/results.html
+++ b/templates/results.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<title>Results</title>
+<h1>Forecast and Inventory Parameters</h1>
+<h2>Forecast</h2>
+<pre>{{ forecast }}</pre>
+<h2>Inventory Parameters</h2>
+<ul>
+  <li>Safety Stock: {{ params['safety_stock'] }}</li>
+  <li>Reorder Point: {{ params['reorder_point'] }}</li>
+</ul>
+<a href="/">Back</a>

--- a/templates/upload.html
+++ b/templates/upload.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<title>Upload CSV</title>
+<h1>Upload demand data</h1>
+<form method=post enctype=multipart/form-data>
+  <input type=file name=file>
+  <label for=periods>Forecast periods:</label>
+  <input type=number name=periods value=1 min=1>
+  <input type=submit value=Upload>
+</form>


### PR DESCRIPTION
## Summary
- add a small Flask application that accepts a CSV upload
- compute a simple moving-average demand forecast
- estimate inventory safety stock and reorder point
- supply HTML templates, requirements and Dockerfile

## Testing
- `python3 -m py_compile app/*.py app.py`


------
https://chatgpt.com/codex/tasks/task_e_688adeb8feb0832ea21bb7b5ccb8a9c2